### PR TITLE
Wrong cursor position when transposing characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "transpose",
 	"displayName": "transpose",
 	"description": "Transpose is an extension for VSCode for transposing/swapping selections or characters.",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"publisher": "v4run",
 	"engines": {
 		"vscode": "^1.5.0"

--- a/src/transpose.ts
+++ b/src/transpose.ts
@@ -71,10 +71,13 @@ class Transposer {
             if (nextPosition == null || prevPosition == null) {
                 return
             }
+            let prevSelection = new Selection(this._prevChar(p), p)
             let nextSelection = new Selection(p, this._nextChar(p))
+
+            let prevChar = this._textEditor.document.getText(prevSelection);
             let nextChar = this._textEditor.document.getText(nextSelection);
-            this._textEditorEdit.delete(nextSelection)
-            this._textEditorEdit.insert(prevPosition, nextChar)
+            this._textEditorEdit.replace(prevSelection, nextChar)
+            this._textEditorEdit.replace(nextSelection, prevChar)
         });
     }
 


### PR DESCRIPTION
If I want to transpose de characters `a` and `b` in the string `abc` the result is `bac` but the cursor is now between `a` and `c`, not between `b` and `a`.
I just don't think it's the desired behavior.